### PR TITLE
Enable SharpYUV when encoding (for lossy)

### DIFF
--- a/src/WebP/WebP.cpp
+++ b/src/WebP/WebP.cpp
@@ -367,6 +367,7 @@ WebPStatus __stdcall WebPSave(
     }
 
     config.method = 6; // 6 is the highest quality encoding
+    config.use_sharp_yuv = 1; // Activates SharpYUV for lossy encoding, which is described as a slower but "more accurate and sharper RGB->YUV conversion". NOTE: in some rare'ish cases this can cause some colors to be more red then they should be however the tradeoff is well worth it overall. "config.preprocessing = 4;" is the old/alternative way to activate this
     config.thread_level = 1;
 
     if (encodeOptions->lossless)


### PR DESCRIPTION
Official description of this is "Use more accurate and sharper RGB->YUV conversion. Note that this process is slower than the default 'fast' RGB->YUV conversion."

Here's an article going over this setting (the image at the top seems to be pretty cherry-picked as I could not replicate or get close to it but overall the article is decent): https://www.ctrl.blog/entry/webp-sharp-yuv.html

Apologies if the comment within the commit next to the code is a bit too long.

Only downsides to this change (besides it being slower) is it makes images very slightly larger (covered in the article) and can semi-rarely make some colors more red then they should be (not covered in the article). however overall these seem like worthwhile tradeoffs for the quality gain and should still be faster when compared to the speed of the current lossless settings set within this repo.