### PR TITLE
Preserve color values of invisible pixels (for lossless)

### DIFF
--- a/src/WebP/WebP.cpp
+++ b/src/WebP/WebP.cpp
@@ -372,6 +372,7 @@ WebPStatus __stdcall WebPSave(
     if (encodeOptions->lossless)
     {
         config.lossless = 1;
+        config.exact = 1; // Preserve color values of invisible/transparent pixels like the built-in PNG output of PDN
         pic->use_argb = 1;
 
         switch (encodeOptions->preset)


### PR DESCRIPTION
Preserves the color values of invisible/transparent pixels when encoding a lossless image like the built-in PNG output of PDN and the built-in JXL plugin's output both do when encoding for a lossless output/export.

**NOTE**: I could not get this repo to compile on my PC to properly test this however I assume the alpha gets passed into libwebp with all the values intact.